### PR TITLE
Fix RightAlternative

### DIFF
--- a/Algebra.Magma.fm
+++ b/Algebra.Magma.fm
@@ -17,7 +17,7 @@ LeftAlternative : {A : Type, f : A -> A -> A} -> Type
   {x : A, y : A} -> f(f(x,x),y) == f(x,f(x,y))
 
 RightAlternative : {A : Type, f : A -> A -> A} -> Type
-  {x : A, y : A} -> f(f(x,x),y) == f(x,f(x,y))
+  {x : A, y : A} -> f(y,f(x,x)) == f(f(y,x),x))
 
 Alternative : {A : Type, f : A -> A -> A} -> Type
   And(LeftAlternative(A,f), RightAlternative(A,f))


### PR DESCRIPTION
RightAlternative was a copy of LeftAlternative; replaced with correct definition.